### PR TITLE
fix: install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     install_requires=[
         "singer-python==5.2.0",
         "pendulum==1.2.0",
-        "tap-kit @ git+https://github.com/dmzobel/tap-kit.git@master"
+        "tap-kit @ git+https://github.com/dmzobel/tap-kit.git@main"
     ],
     dependency_links=[
-        "https://github.com/dmzobel/tap-kit/tarball/master#egg=tap-kit-0.1.1",
+        "https://github.com/dmzobel/tap-kit/tarball/main#egg=tap-kit-0.1.1",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
@dmzobel @erenerdo I was getting an error during installation `error: pathspec 'master' did not match any file(s) known to git` since the tap-kit repo changed from the master branch to main branch. This resolves the install issues.